### PR TITLE
Create measured fidgets registration api

### DIFF
--- a/app/assets/stylesheets/measured_fidgets.scss
+++ b/app/assets/stylesheets/measured_fidgets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the measured_fidgets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/api/v1/measured_fidgets_controller.rb
+++ b/app/controllers/api/v1/measured_fidgets_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::MeasuredFidgetsController < Api::V1::BaseController
+  def create
+    measured_fidget = @_current_user.measured_fidgets.build(measured_fidget_params)
+    if measured_fidget.save
+      head :ok
+    else
+      render_bad_request nil, measured_fidget.errors.full_messages
+    end
+  end
+
+  private
+
+  def measured_fidget_params
+    params.require(:measured_fidget).permit(:detected_at, :fidget_level, :measured_time)
+  end
+end

--- a/app/controllers/measured_fidgets_controller.rb
+++ b/app/controllers/measured_fidgets_controller.rb
@@ -1,0 +1,5 @@
+class MeasuredFidgetsController < ApplicationController
+  def index
+    @measured_fidgets = current_user.measured_fidgets
+  end
+end

--- a/app/helpers/measured_fidgets_helper.rb
+++ b/app/helpers/measured_fidgets_helper.rb
@@ -1,0 +1,2 @@
+module MeasuredFidgetsHelper
+end

--- a/app/views/measured_fidgets/_measured_fidget.html.slim
+++ b/app/views/measured_fidgets/_measured_fidget.html.slim
@@ -1,4 +1,4 @@
-= tag.tr class: "measured_fidget_#{measured_fidget.id}"
+= tag.tr class: "measured_fidget"
   td = measured_fidget.detected_at
   td = measured_fidget.fidget_level
   td = measured_fidget.measured_time

--- a/app/views/measured_fidgets/_measured_fidget.html.slim
+++ b/app/views/measured_fidgets/_measured_fidget.html.slim
@@ -1,0 +1,4 @@
+= tag.tr class: "measured_fidget_#{measured_fidget.id}"
+  td = measured_fidget.detected_at
+  td = measured_fidget.fidget_level
+  td = measured_fidget.measured_time

--- a/app/views/measured_fidgets/_measured_fidgets.html.slim
+++ b/app/views/measured_fidgets/_measured_fidgets.html.slim
@@ -1,0 +1,1 @@
+= render measured_fidgets

--- a/app/views/measured_fidgets/index.html.slim
+++ b/app/views/measured_fidgets/index.html.slim
@@ -1,0 +1,12 @@
+h1 MeasuredFidgets#index
+p Find me in app/views/measured_fidgets/index.html.slim
+
+.mb-3
+  table.table.table-hover
+    thead.thead-default
+      tr
+        th = "detected_at"
+        th = "fidget_level"
+        th = "measured_time"
+    tbody
+      = render 'measured_fidgets', measured_fidgets: @measured_fidgets

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,12 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     namespace :v1 do
       post 'authentication', to: 'authentication#create'
+      resources :measured_fidgets, only: %i[create]
     end
   end
   root 'users#new'
   resources :users, only: %i[new create destroy edit update show]
+  resources :measured_fidgets, only: %i[index]
   get 'login', to: 'authentication#new'
   post 'login', to: 'authentication#create'
   delete 'logout', to: 'authentication#destroy'

--- a/spec/controllers/measured_fidgets_controller_spec.rb
+++ b/spec/controllers/measured_fidgets_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe MeasuredFidgetsController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/factories/measured_fidgets.rb
+++ b/spec/factories/measured_fidgets.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :measured_fidget do
-    user { nil }
     detected_at { "2021-03-31 23:56:18" }
     fidget_level { 1.5 }
     measured_time { 1.5 }

--- a/spec/helpers/measured_fidgets_helper_spec.rb
+++ b/spec/helpers/measured_fidgets_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the MeasuredFidgetsHelper. For example:
+#
+# describe MeasuredFidgetsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe MeasuredFidgetsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include ResponseHelper
+  config.include LoginHelper
 end

--- a/spec/requests/api/v1/measured_fidgets_spec.rb
+++ b/spec/requests/api/v1/measured_fidgets_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'measured_fidgets', type: :request do
+  let!(:password) { 'password' }
+  let!(:user) { create(:user, password: password, password_confirmation: password) }
+  let!(:api_key){ create(:api_key, user: user) }
+
+  describe "POST api/v1/measured_fidgets" do
+    let!(:measured_fidget) { build(:measured_fidget) }
+    context "measured_fidgetモデルのjsonデータをPostした時" do
+      let(:measured_fidget_params) { attributes_for(:measured_fidget) }
+      it 'measured_fidgetが登録されること' do
+        measured_fidget_count = MeasuredFidget.count
+        post api_v1_measured_fidgets_path, params: measured_fidget_params.to_json, headers: { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer #{api_key.access_token}" }
+        expect(status).to eq 200
+        expect(response.body).to eq ""
+        expect(MeasuredFidget.count).to eq measured_fidget_count + 1
+      end
+    end
+
+    context "measured_fidgetモデルではないjsonデータをPostした時" do
+      let(:user_params) { attributes_for(:user) }
+      it '500が返されること' do
+        measured_fidget_count = MeasuredFidget.count
+        post api_v1_measured_fidgets_path, params: user_params.to_json, headers: { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json', Authorization: "Bearer #{api_key.access_token}" }
+        expect(status).to eq 500
+      end
+    end
+
+    context "api_keyなしでjsonデータをPostした時" do
+      let(:measured_fidget_params) { attributes_for(:measured_fidget) }
+      it '401が返されること' do
+        measured_fidget_count = MeasuredFidget.count
+        post api_v1_measured_fidgets_path, params: measured_fidget_params.to_json, headers: { CONTENT_TYPE: 'application/json', ACCEPT: 'application/json' }
+        expect(status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,0 +1,8 @@
+module LoginHelper
+  def login(email, password)
+    visit login_path
+    fill_in 'Email', with: email
+    fill_in 'Password', with: password
+    click_on 'login'
+  end
+end

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -5,20 +5,16 @@ RSpec.describe 'Authentications', type: :system do
   let!(:user) { create(:user, password: password, password_confirmation: password) }
   let!(:setting) { create(:setting, user: user) }
   describe 'ログイン' do
-    before { visit login_path }
     context 'ログイン情報が登録情報と一致する時' do
       it 'ログインできること' do
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: password
-        click_on 'login'
+        login(user.email, password)
 
         expect(current_path).to eq user_path(user)
       end
     end
     context 'ログイン情報が登録情報と一致しない時' do
       it 'ログインできないこと' do
-        fill_in 'Email', with: nil
-        fill_in 'Password', with: nil
+        login(nil, nil)
 
         expect(current_path).to eq login_path
       end

--- a/spec/system/measured_fidgets_spec.rb
+++ b/spec/system/measured_fidgets_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'MeasuredFidgets', type: :system do
+  let!(:password) { 'password' }
+  let!(:user) { create(:user, password: password, password_confirmation: password) }
+  let!(:setting) { create(:setting, user: user) }
+  let!(:measured_fidgets) { create_list(:measured_fidget, 10, user: user) }
+  let!(:another_user) { create(:user, password: password, password_confirmation: password) }
+  let!(:another_measured_fidgets) { create_list(:measured_fidget, 5, user: another_user) }
+
+  describe '一覧' do
+    context 'ログインしたユーザの場合' do
+      before { login(user.email, password) }
+      it 'ユーザのmeasured_fidgetsが表示されること' do
+        visit measured_fidgets_path
+
+        expect(page.all(".measured_fidget").count).to eq measured_fidgets.count
+      end
+    end
+
+    context 'ログインしていないユーザの場合' do
+      it 'ログインページが表示されること' do
+        visit measured_fidgets_path
+
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+end

--- a/spec/views/measured_fidgets/index.html.slim_spec.rb
+++ b/spec/views/measured_fidgets/index.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "measured_fidgets/index.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要

スマホで検出したmeasured_fidgetsの登録APIを作成しました。
また、上記確認用のページ`/measured_fidgets`を作成しました。

## 確認方法

1. `/api/v1/measured_fidgets/`に下記json形式のmeasured_fidgetデータをPostしてください。

```
{
    "detected_at": "2021/04/05",
    "fidget_level": 3.3,
    "measured_time": 1.1
}
```

2. レスポンスコード200が返ってくることを確認してください。
3. ログイン後、measured_fidgets確認用のページ`/measured_fidgets/`にアクセスできることを確認してください。
4. Postしたデータが一覧で表示されていることを確認してください。

## チェックリスト

- [x] インテグレーションテストを追加した
- [x] Lint のチェックをパスした
- [x] インテグレーションテストをパスした（[チェック結果](https://github.com/FukiHayashi/fidgeting_meter/issues/7)）

## コメント

- ページレイアウトができていませんが、これはissue:[ページレイアウトの調整](https://github.com/FukiHayashi/fidgeting_meter/issues/14)で調整予定です。